### PR TITLE
Handle missing SurvSet.resources module in loader fallback

### DIFF
--- a/SurvSet/data.py
+++ b/SurvSet/data.py
@@ -32,8 +32,8 @@ class SurvLoader():
         """Return the pickles resource directory in a version-safe way."""
         try:
             return pkg_resources.files(self.path_to_data)
-        except (TypeError, AttributeError):
-            # Python 3.9 may fail for namespace packages with spec.origin=None.
+        except (TypeError, AttributeError, ModuleNotFoundError, ImportError):
+            # Some installed environments cannot import SurvSet.resources as a package.
             return pkg_resources.files("SurvSet").joinpath("resources", "pickles")
 
     def load_pickle(self, name: str) -> pd.DataFrame:

--- a/tests/test_survloader.py
+++ b/tests/test_survloader.py
@@ -42,6 +42,22 @@ class TestSurvLoader(unittest.TestCase):
         self.assertIn("ds", df_ds.columns)
         self.assertGreater(len(df_ds), 0)
 
+    def test_resource_root_fallback_when_namespace_package_missing(self):
+        real_files = std_pkg_resources.files
+
+        def files_with_missing_namespace(package):
+            if package == "SurvSet.resources.pickles":
+                raise ModuleNotFoundError("No module named 'SurvSet.resources'")
+            return real_files(package)
+
+        with patch("SurvSet.data.pkg_resources.files", side_effect=files_with_missing_namespace):
+            loader = SurvLoader()
+            df_ds = loader.load_csv("df_ds.csv")
+
+        self.assertIsInstance(df_ds, pd.DataFrame)
+        self.assertIn("ds", df_ds.columns)
+        self.assertGreater(len(df_ds), 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Catch ModuleNotFoundError/ImportError in resource lookup and add regression test for missing namespace package.