### PR TITLE
Add install smoke test script for git refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,15 @@ You can start by creating a virtual environment to align with the development en
 2. `pip install -r requirements.txt`
 3. `source surv/bin/activate`
 
+### Pre-merge install smoke test
+
+Before merging a packaging-related fix, run a clean install smoke test from a Git ref:
+
+1. `scripts/smoke_install_ref.sh main`
+2. `scripts/smoke_install_ref.sh <branch-or-commit>`
+
+This creates a temporary virtual environment, installs `SurvSet` from the specified ref, and runs `python -m SurvSet`.
+
 ### How to add a new package/dataset
 
 The SurvSet._datagen module will generate the underlying raw data and process it. There are currently two ways to add a dataset:

--- a/scripts/smoke_install_ref.sh
+++ b/scripts/smoke_install_ref.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_URL="https://github.com/ErikinBC/SurvSet.git"
+REF="${1:-main}"
+
+if [[ "${REF}" == "-h" || "${REF}" == "--help" ]]; then
+  cat <<'EOF'
+Usage:
+  scripts/smoke_install_ref.sh [git-ref]
+
+Examples:
+  scripts/smoke_install_ref.sh
+  scripts/smoke_install_ref.sh main
+  scripts/smoke_install_ref.sh bb65b13
+  scripts/smoke_install_ref.sh fix/issue-5-module-not-found
+EOF
+  exit 0
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "ERROR: python3 is required but not found in PATH." >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "${TMP_DIR}"
+}
+trap cleanup EXIT
+
+echo "[1/4] Creating fresh virtual environment..."
+python3 -m venv "${TMP_DIR}/venv"
+
+echo "[2/4] Installing SurvSet from ref '${REF}'..."
+"${TMP_DIR}/venv/bin/pip" install --no-cache-dir "SurvSet @ git+${REPO_URL}@${REF}" >/tmp/survset_smoke_install.log
+
+echo "[3/4] Verifying installed loader fallback source..."
+"${TMP_DIR}/venv/bin/python" - <<'PY'
+import inspect
+import SurvSet.data as data
+print(inspect.getsource(data.SurvLoader._resource_root))
+PY
+
+echo "[4/4] Running package entrypoint..."
+"${TMP_DIR}/venv/bin/python" -m SurvSet
+
+echo "PASS: Smoke install test succeeded for ref '${REF}'."


### PR DESCRIPTION
Create scripts/smoke_install_ref.sh to validate fresh venv installs from branch/commit refs before merge. Document usage in README.